### PR TITLE
Fix native out of bound access

### DIFF
--- a/src/Formats/NativeReader.cpp
+++ b/src/Formats/NativeReader.cpp
@@ -175,8 +175,8 @@ Block NativeReader::read()
             auto & header_column = header.getByName(column.name);
             if (!header_column.type->equals(*column.type))
             {
-                column.column = recursiveTypeConversion(column.column, column.type, header.getByPosition(i).type);
-                column.type = header.getByPosition(i).type;
+                column.column = recursiveTypeConversion(column.column, column.type, header.safeGetByPosition(i).type);
+                column.type = header.safeGetByPosition(i).type;
             }
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category:

Bug Fix
Changelog entry:

Fixed Apache Avro Union type index out of boundary issue in Apache Avro binary format.

Detailed description / Documentation draft:

ClickHouse supports input and output in the Native Format. When deserializing this data in to clickhouse structures , Clickhouse can be provided by header block which specifies the format of the table which holds the incoming data specified in the input stream. ClickHouse will attempt to take the input data and insert it
correctly, but a vulnerability exists when the number of columns input exceeds the number
of columns defined in the header.

Steps to Reproduce the issue:

clickhouse-local --query "SELECT toString(number) AS a, toString(number) AS a FROM numbers(10)" --output-format Native | clickhouse-local --query "SELECT * FROM table" --input-format Native --structure 'a LowCardinality(String)'

Solution :
The function call to
getByPosition() in Nativereader::readImpl() is replaced by safeGetByPosition(size_t position) defined in Block.h . This function does out of bound validation.