### PR TITLE
Equal function produces LowCardinality(UInt8) instead of UInt8

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -175,11 +175,24 @@ const ActionsDAG::Node & ActionsDAG::addFunction(
         argument.column = child.column;
         argument.type = child.result_type;
         argument.name = child.result_name;
-
         if (!argument.column || !isColumnConst(*argument.column))
             all_const = false;
 
         arguments[i] = std::move(argument);
+    }
+
+    if(num_arguments > 1 && arguments[0].type != arguments[1].type)
+    {
+        const auto * arg_0_type_ptr=typeid_cast<const DataTypeLowCardinality *>(arguments[0].type.get());
+        const auto * arg_1_type_ptr=typeid_cast<const DataTypeLowCardinality *>(arguments[1].type.get());
+        if (arg_0_type_ptr != nullptr & arg_1_type_ptr == nullptr)
+        {
+            arguments[0].type=arguments[1].type;
+        }
+        else if(arg_0_type_ptr == nullptr & arg_1_type_ptr != nullptr)
+        {
+            arguments[1].type=arguments[0].type;
+        }
     }
 
     node.function_base = function->build(arguments);


### PR DESCRIPTION
Changelog category (leave one):
- Bug Fix (user-visible misbehaviour in official stable or prestable release)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

toLowCardinality('foo') == 'foo' and 'foo' == 'foo' returns different types.


Detailed description / Documentation draft:
Problem Description: 
In CH, equals(toLowCardinality('foo') , 'foo') is returning LowCardinality(UInt8) and  equals('foo', 'foo') is returning UInt8. 
which is inconsistent.

Solution: 
To address this inconsistency, checking whether either of the argument is LowCardinality type and passing to equals build function as same type. if both are LowCardinality type, CH works as usual. Also it wont have any negative impact on any other dictionary types as the condition is very specific two equals funciton.

I have verified below scenarios: 

1) Desc table(select 'a'='a')  returning  UInt8	 
2) Desc table(select toLowCardinality('a')='a')    returning   UInt8
3) SELECT toTypeName(if(toLowCardinality('a') LIKE 'a', 1, 2))  returns   	UInt8
3) SELECT toTypeName(if('a' LIKE 'a', 1, 2))     returning UInt8

> By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

> If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


> Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
