### PR TITLE
Fix space after @ bug in verbatim strings

### DIFF
--- a/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
@@ -440,6 +440,11 @@ String IParserKQLFunction::iterativelyEscapeString(IParser::Pos pos)
                 throw DB::Exception(DB::ErrorCodes::SYNTAX_ERROR, "Verbatim string expected a string literal to follow @");
             if (pos->end - pos->begin < 2 || (*(pos->begin) != '\'' && *(pos->begin) != '\"'))
                 throw DB::Exception(DB::ErrorCodes::SYNTAX_ERROR, "Internal Error: misformed vertbatim string tokens");
+            // catch disallowed whitespace that can get lost during tokenization 
+            if (*(pos->begin - 1) != '@')
+            {
+                throw DB::Exception(DB::ErrorCodes::SYNTAX_ERROR, "Space cannot folllow @ in verbatim string");
+            }
             String verbatimString = "";
             const bool is_outer_quote_double = (*(pos->begin) == '\"');
             do

--- a/tests/queries/0_stateless/02366_kql_func_string.sql
+++ b/tests/queries/0_stateless/02366_kql_func_string.sql
@@ -666,3 +666,5 @@ print  @"\a" == "\\a";
 print  @"\a" != @"\\a";
 print @"\\a" != "\\a";
 print "\\a" == @"\\a";
+print @ "hello"; -- { clientError SYNTAX_ERROR }
+print trim_end(@ "\\", @"a\\\\"); -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
Fixes bug in verbatim strings where a space is allowed after `@`. Statements like `print @ "a"` now correctly error. 